### PR TITLE
works for ng-href

### DIFF
--- a/src/directives/scrollspy.js
+++ b/src/directives/scrollspy.js
@@ -79,8 +79,9 @@ directive('duScrollspy', function($rootScope, scrollPosition) {
 
   return {
     link: function ($scope, $element, $attr) {
-      if (!$attr.href || $attr.href.indexOf('#') === -1) return;
-      var targetId = $attr.href.replace(/.*(?=#[^\s]+$)/, '').substring(1);
+      var href = $attr['ng-href'] || $attr.href;
+      if (!href || href.indexOf('#') === -1) return;
+      var targetId = href.replace(/.*(?=#[^\s]+$)/, '').substring(1);
       if(!targetId) return;
 
       var spy = new Spy(targetId, $element, -($attr.offset ? parseInt($attr.offset, 10) : 0));


### PR DESCRIPTION
Angular recommends using [ng-href](http://docs.angularjs.org/api/ng/directive/ngHref) over href for values which need to get interpreted. I modified the scrollspy directive to use whichever of ng-href or href the element uses.
