### PR TITLE
broadcast events when elements become active

### DIFF
--- a/src/directives/scrollspy.js
+++ b/src/directives/scrollspy.js
@@ -54,8 +54,14 @@ directive('duScrollspy', function($rootScope, scrollPosition) {
       toBeActive = toBeActive.spy;
     }
     if(currentlyActive === toBeActive) return;
-    if(currentlyActive) currentlyActive.$element.removeClass('active');
-    if(toBeActive) toBeActive.$element.addClass('active');
+    if(currentlyActive) {
+      currentlyActive.$element.removeClass('active');
+      $rootScope.$broadcast('inactive', currentlyActive.$element);
+    }
+    if(toBeActive) {
+      toBeActive.$element.addClass('active');
+      $rootScope.$broadcast('active', toBeActive.$element);
+    }
     currentlyActive = toBeActive;
   }
 


### PR DESCRIPTION
Uses $rootScope.$broadcast to give a shout when elements become active, pursuant to conversation in https://github.com/durated/angular-scroll/pull/9
