### PR TITLE
#19 Allow scrollspy inside of scroll context

### DIFF
--- a/example/context.html
+++ b/example/context.html
@@ -74,6 +74,7 @@
 
     #container {
       overflow: auto;
+      position: relative;
       height: 400px;
       padding: 0;
       margin: 10px 0 20px 0;
@@ -85,9 +86,9 @@
 <div class="wrap" ng-controller="MyCtrl">
   <nav du-scroll-context="container">
     <ul>
-      <li><a href="#section-1" du-smooth-scroll>Section 1</a></li>
-      <li><a href="#section-2" du-smooth-scroll>Section 2</a></li>
-      <li><a href="#section-3" du-smooth-scroll>Section 3</a></li>
+      <li><a href="#section-1" du-scrollspy du-smooth-scroll>Section 1</a></li>
+      <li><a href="#section-2" du-scrollspy du-smooth-scroll>Section 2</a></li>
+      <li><a href="#section-3" du-scrollspy du-smooth-scroll>Section 3</a></li>
       <li><a href="http://github.com/durated/angular-scroll/">Project on Github</a></li>
     </ul>
   </nav>
@@ -127,7 +128,7 @@
 </div>
 
 <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.2.14/angular.min.js"></script>
-<script src="http://durated.github.io/angular-scroll/angular-scroll.min.js"></script>
+<script src="../angular-scroll.js"></script>
 <script>
 angular.module('myApp', ['duScroll']).
   controller('MyCtrl', function($scope, scroller){

--- a/src/directives/scrollspy.js
+++ b/src/directives/scrollspy.js
@@ -1,6 +1,6 @@
-angular.module('duScroll.scrollspy', ['duScroll.spyAPI']).
-directive('duScrollspy', function(duSpyAPI) {
-  var Spy = function(targetElementOrId, $element, offset) {
+angular.module('duScroll.scrollspy', ['duScroll.spyAPI', 'duScroll.scrollContextAPI']).
+directive('duScrollspy', function($timeout, duSpyAPI, duScrollContextAPI) {
+  var Spy = function(targetElementOrId, $element, offset, scrollContext) {
     if(angular.isElement(targetElementOrId)) {
       this.target = targetElementOrId;
     } else if(angular.isString(targetElementOrId)) {
@@ -8,6 +8,7 @@ directive('duScrollspy', function(duSpyAPI) {
     }
     this.$element = $element;
     this.offset = offset;
+    this.scrollContext = scrollContext;
   };
 
   Spy.prototype.getTargetElement = function() {
@@ -19,7 +20,19 @@ directive('duScrollspy', function(duSpyAPI) {
 
   Spy.prototype.getTargetPosition = function() {
     var target = this.getTargetElement();
-    if(target) {
+    if(target && this.scrollContext){
+      var el = target;
+      var top = el.offsetTop;
+      while (el.offsetParent !== this.scrollContext) {
+        top+= el.offsetTop;
+        el = el.offsetParent;
+      }
+      return {
+        top: top - this.scrollContext.scrollTop,
+        height: target.offsetHeight
+      };
+    }
+    if(target && !this.scrollContext) {
       return target.getBoundingClientRect();
     }
   };
@@ -33,7 +46,7 @@ directive('duScrollspy', function(duSpyAPI) {
   return {
     link: function ($scope, $element, $attr) {
       var href = $attr.ngHref || $attr.href;
-      var targetId;
+      var targetId, spy;
 
       if (href && href.indexOf('#') !== -1) {
         targetId = href.replace(/.*(?=#[^\s]+$)/, '').substring(1);
@@ -42,13 +55,19 @@ directive('duScrollspy', function(duSpyAPI) {
       }
       if(!targetId) return;
 
-      var spy = new Spy(targetId, $element, -($attr.offset ? parseInt($attr.offset, 10) : 0));
-      duSpyAPI.addSpy(spy);
+      // Run this in the next execution loop so that the scroll context has a chance
+      // to initialize
+      $timeout(function() {
+        var scrollContext = duScrollContextAPI.getContext($scope);
+        spy = new Spy(targetId, $element, -($attr.offset ? parseInt($attr.offset, 10) : 0), scrollContext);
 
-      $scope.$on('$destroy', function() {
-        duSpyAPI.removeSpy(spy);
-      });
-      $scope.$on('$locationChangeSuccess', spy.flushTargetCache.bind(spy));
+        duSpyAPI.addSpy(spy);
+
+        $scope.$on('$destroy', function() {
+          duSpyAPI.removeSpy(spy);
+        });
+        $scope.$on('$locationChangeSuccess', spy.flushTargetCache.bind(spy));
+      }, 0);
     }
   };
 });

--- a/src/services/spy-api.js
+++ b/src/services/spy-api.js
@@ -11,6 +11,7 @@ factory('duSpyAPI', function($rootScope, scrollPosition) {
     return id;
   };
   var defaultContextId = createContext($rootScope);
+  var scrollContexts = {};
 
   var gotScroll = function($event, scrollY) {
     var i, id, context, currentlyActive, toBeActive, spies, spy, pos;
@@ -69,6 +70,20 @@ factory('duSpyAPI', function($rootScope, scrollPosition) {
     if(!isObserving) {
       $rootScope.$on('$duScrollChanged', gotScroll);
       isObserving = true;
+    }
+    var sC = spy.scrollContext;
+    if(sC){
+      var scope = angular.element(sC).scope();
+      var scId = scope.$id;
+
+      if(!scrollContexts[scId]){
+        scrollContexts[scId] = angular.element(sC).on('scroll', function(){
+          gotScroll(null,sC.scrollTop);
+        });
+        scope.$on('$destroy', function(){
+          delete scrollContexts[scId];
+        });
+      }
     }
     getContextForSpy(spy).spies.push(spy);
   };


### PR DESCRIPTION
This is a somewhat naive implementation, and requires the scrollable
container to be positioned with `relative` or `absolute` (because we're
using `offsetTop` and `offsetHeight` and `offsetParent` to determine the
"spied" element's position within its container.)

A more robust solution can/should be explored.  However, the current
implementation appears to work, and the context.html demo has been
updated to include spies.

Feedback is always welcome!

Original issue being discussed in #19
