### PR TITLE
Fixed bug in way total anim frames are calculated

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -43,7 +43,7 @@ run(function($window, requestAnimation, duScrollEasing) {
 
     if(!deltaLeft && !deltaTop) return;
 
-    var frame = 0, frames = Math.ceil(duration/60);
+    var frame = 0, frames = Math.ceil(duration*60/1000);
 
     var animate = function() {
       frame++;


### PR DESCRIPTION
I was animating document scrollTo with a duration( 1500ms ) but animation was running way faster than I expected. After some research I found that the way frames are calculated is wrong.

Can you confirm me that is a a bug or if I am doing something wrong?

Thanks
