### PR TITLE
Fixed scrolledToElement arguments call in scrollTo

### DIFF
--- a/angular-scroll.js
+++ b/angular-scroll.js
@@ -39,7 +39,7 @@ run(function($window, $q, cancelAnimation, requestAnimation, duScrollEasing) {
 
   proto.scrollTo = function(left, top, duration, easing) {
     if(angular.isElement(left)) {
-      return this.scrollToElement(left, 0, top, duration);
+      return this.scrollToElement.apply(this, arguments);
     }
     if(duration) {
       return this.scrollToAnimated.apply(this, arguments);


### PR DESCRIPTION
Hi, is there any particular reason why the arguments in which you call `scrolledToElement` are set like `(left, 0, top, duration)`? Its signature indicates it expects a different set of arguments `(target, offset, duration, easing)`, i.e., the same arguments the `scrolledToElement` function gets. Am I missing something or is this patch correct? Thanks!
