### PR TITLE
Add support of angular-ui/ui-router states change

### DIFF
--- a/src/directives/scrollspy.js
+++ b/src/directives/scrollspy.js
@@ -52,6 +52,7 @@ directive('duScrollspy', function(spyAPI, $timeout) {
           spyAPI.removeSpy(spy);
         });
         $scope.$on('$locationChangeSuccess', spy.flushTargetCache.bind(spy));
+        $scope.$on('$stateChangeSuccess', spy.flushTargetCache.bind(spy));
       }, 0);
     }
   };


### PR DESCRIPTION
Compatibility with popular [angular-ui/ui-router](https://github.com/angular-ui/ui-router). This addition make scroll spy working not only if location changes (typical behavior for ngRoute), but and if state changes without modifying url by adding `$stateChangeSuccess` event listener.
