### PR TITLE
Issue #40: Cancel scroll on mouse wheel (Cont)

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -58,9 +58,13 @@ run(function($window, $q, cancelAnimation, requestAnimation, duScrollEasing) {
       return deferred.promise;
     }
 
-    var cancelOnScroll = function() {
-      cancelAnimation(scrollAnimation);
-      deferred.reject();
+    var cancelScrollEvents = 'scroll mousedown mousewheel touchmove keydown',
+        cancelScrollFn = function(event) {
+      if (event.which > 0) {
+        angular.element($window).unbind(cancelScrollEvents);
+        cancelAnimation(scrollAnimation);
+        deferred.reject();
+      }
     };
 
     var animationStep = function(timestamp) {
@@ -78,7 +82,7 @@ run(function($window, $q, cancelAnimation, requestAnimation, duScrollEasing) {
       if(percent < 1) {
         scrollAnimation = requestAnimation(animationStep);
       } else {
-        angular.element($window).unbind('mousewheel', cancelOnScroll);
+        angular.element($window).unbind(cancelScrollEvents, cancelScrollFn);
         scrollAnimation = null;
         deferred.resolve();
       }
@@ -86,7 +90,7 @@ run(function($window, $q, cancelAnimation, requestAnimation, duScrollEasing) {
 
     //Fix random mobile safari bug when scrolling to top by hitting status bar
     el.scrollTo(startLeft, startTop);
-    angular.element($window).bind('mousewheel', cancelOnScroll);
+    angular.element($window).bind(cancelScrollEvents, cancelScrollFn);
 
     scrollAnimation = requestAnimation(animationStep);
     return deferred.promise;


### PR DESCRIPTION
Ok had another think and a bit of research on this. I've added in the `touchmove` event for the smart phones, for the clicking on the scroll bars, the window counts this as a `mousedown` event, but this also means that clicking anywhere on the page will cancel the animation... not sure if this is a good thing? I've also added the `keydown` event as previously mentioned in the issue. 

Let me know what you think :)
