### PR TITLE
Fixes : jshint, strict mode, jshint globals

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,7 +30,7 @@ gulp.task('clean', function() {
 
 gulp.task('lint', function() {
   gulp.src(sources)
-    .pipe(jshint())
+    .pipe(jshint({ browser: true }))
     .pipe(jshint.reporter('default'));
 });
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,9 +1,15 @@
+"use strict";
+/*global angular,HTMLDocument*/
+
 angular.module('duScroll.scrollHelpers', []).
 run(function($window, $q, cancelAnimation, requestAnimation, duScrollEasing) {
   var proto = angular.element.prototype;
-  this.$get = function() {
-    return proto;
-  };
+  if (this) {
+    this.$get = function() {
+      return proto;
+    };
+  }
+
 
   var isDocument = function(el) {
     return (typeof HTMLDocument !== 'undefined' && el instanceof HTMLDocument) || (el.nodeType && el.nodeType === el.DOCUMENT_NODE);
@@ -100,6 +106,9 @@ run(function($window, $q, cancelAnimation, requestAnimation, duScrollEasing) {
 
   proto.scrollToElement = function(target, offset, duration, easing) {
     var el = unwrap(this);
+    if (typeof offset === 'undefined') {
+      offset = 0;
+    }
     var top = this.scrollTop() + unwrap(target).getBoundingClientRect().top - offset;
     if(isElement(el)) {
       top -= el.getBoundingClientRect().top;


### PR DESCRIPTION
I had some trouble using angular-scroll in my project, when things broke after packaging my app in a minified file (including angular-scroll.js)

I realized two things : 
- The line `this.$get = function() {` in `helpers.js` would not work when minified, `this` becoming undefined (don't know why)
- The behaviour is the same, non minified, if the file is parsed with `"use strict";` at the beginning of the file

Example output of the tests :

```
Chrome 35.0.1916 (Mac OS X 10.9.4) service scrollContainerAPI should default to $document FAILED
  TypeError: Cannot set property '$get' of undefined
    at /Users/pandaiolo/Sites/angular-scroll/src/helpers.js:6:13
    at Object.invoke (/Users/pandaiolo/Sites/angular-scroll/bower_components/angular/angular.js:3917:17)
    at /Users/pandaiolo/Sites/angular-scroll/bower_components/angular/angular.js:3763:71
    at Array.forEach (native)
    at forEach (/Users/pandaiolo/Sites/angular-scroll/bower_components/angular/angular.js:325:11)
    at Object.createInjector [as injector] (/Users/pandaiolo/Sites/angular-scroll/bower_components/angular/angular.js:376
```

Other issues found/fixed : 
- JSHint complains about some globals : fixed by adding `browser = true` option  in gulpfile, and specifying globals in file `helpers.js`
- In Chrome, not defining `offset` when calling `scrollToElement(...)` result in `top` variable equals `NaN` because `Number` + `undefined` = `NaN`. Maybe Chrome-only issue, but breaks everything :-). Fix is to explicitly set `offset` to 0 when undefined

**PR Notes**
- Tests : they all pass, except the "service requestAnimation callback should be called within 100ms" which fails until I raise the timeout to 1sec. I assumed it was my setup that was too slow, and left it as is.
