### PR TITLE
Loosen angular dep in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,9 +13,9 @@
     "Gruntfile.js"
   ],
   "dependencies": {
-    "angular": "~1.2.16"
+    "angular": "^1.2.16"
   },
   "devDependencies": {
-    "angular-mocks": "~1.2.16"
+    "angular-mocks": "^1.2.16"
   }
 }


### PR DESCRIPTION
This allows to use in project with angular 1.3.0-beta\* installed and bower won't complain
