### PR TITLE
Fixed variable scope to allow simultaneous scrolling

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -34,8 +34,8 @@ angular.module('duScroll.scrollHelpers', ['duScroll.requestAnimation'])
     el.scrollTop = top;
   };
 
-  var scrollAnimation, deferred;
   proto.scrollToAnimated = function(left, top, duration, easing) {
+    var scrollAnimation, deferred;
     if(duration && !easing) {
       easing = duScrollEasing;
     }


### PR DESCRIPTION
Fix for #58.

Fix for incorrectly scoped variables which prevented scrolling across multiple containers.
