### PR TITLE
Prevent unnecessary digest cycles.

### DIFF
--- a/src/directives/scrollspy.js
+++ b/src/directives/scrollspy.js
@@ -55,7 +55,7 @@ angular.module('duScroll.scrollspy', ['duScroll.spyAPI'])
         });
         $scope.$on('$locationChangeSuccess', spy.flushTargetCache.bind(spy));
         $rootScope.$on('$stateChangeSuccess', spy.flushTargetCache.bind(spy));
-      }, 0);
+      }, 0, false);
     }
   };
 });

--- a/src/services/spy-api.js
+++ b/src/services/spy-api.js
@@ -6,7 +6,7 @@ angular.module('duScroll.spyAPI', ['duScroll.scrollContainerAPI'])
     var timer = false, queued = false;
     var handler = function() {
       queued = false;
-      var container = context.container, 
+      var container = context.container,
           containerEl = container[0],
           containerOffset = 0;
 
@@ -47,7 +47,7 @@ angular.module('duScroll.spyAPI', ['duScroll.scrollContainerAPI'])
       }
       context.currentlyActive = toBeActive;
     };
-    
+
     if(!duScrollSpyWait) {
       return handler;
     }
@@ -61,7 +61,7 @@ angular.module('duScroll.spyAPI', ['duScroll.scrollContainerAPI'])
           if(queued) {
             handler();
           }
-        }, duScrollSpyWait);
+        }, duScrollSpyWait, false);
       } else {
         queued = true;
       }
@@ -75,10 +75,10 @@ angular.module('duScroll.spyAPI', ['duScroll.scrollContainerAPI'])
     var context = {
       spies: []
     };
-    
+
     context.handler = createScrollHandler(context);
     contexts[id] = context;
-    
+
     $scope.$on('$destroy', function() {
       destroyContext($scope);
     });
@@ -156,7 +156,7 @@ angular.module('duScroll.spyAPI', ['duScroll.scrollContainerAPI'])
 
   return {
     addSpy: addSpy,
-    removeSpy: removeSpy, 
+    removeSpy: removeSpy,
     createContext: createContext,
     destroyContext: destroyContext,
     getContextForScope: getContextForScope


### PR DESCRIPTION
Without this change, the new handler throttling added by @oblador in #53 will cause a digest cycle to be run with every scroll callback, negating any performance advantage.  The handler doesn't appear to need to be run inside a digest cycle, since the only Angular-related code is the broadcasting of the becameInactive and becameActive events, but the sample code in the README.md makes clear that listeners need to force their own digest via $scope.$apply().

I also removed an unnecessary digest in scrollspy.js, but that one doesn't have any performance implications.

AFAICT these changes don't break anything (my app works as before) but I was unable to run regression tests so caveat emptor.
