### PR TITLE
Prevent error when scope disappears too quickly.

### DIFF
--- a/src/services/spy-api.js
+++ b/src/services/spy-api.js
@@ -133,7 +133,8 @@ angular.module('duScroll.spyAPI', ['duScroll.scrollContainerAPI'])
 
   var addSpy = function(spy) {
     var context = getContextForSpy(spy);
-    getContextForSpy(spy).spies.push(spy);
+    if (!context) return;
+    context.spies.push(spy);
     if (!context.container || !isElementInDocument(context.container)) {
       if(context.container) {
         context.container.off('scroll', context.handler);


### PR DESCRIPTION
If a scope is deleted as soon as it's created (don't ask, it can happen), then the deferred call to addSpy from the scrollspy directive won't be able to find any context.  Just give up silently when that happens.
