### PR TITLE
Have bower.json "main" field point to the unminified script.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "angular-scroll",
   "version": "0.6.2",
-  "main": "angular-scroll.min.js",
+  "main": "angular-scroll.js",
   "ignore": [
     "**/.*",
     "node_modules",


### PR DESCRIPTION
In a project I am currently working on, I was planning to use wiredep to resolve angular-scroll as a dependency of my project, but the "main" field in this project's bower.json points to the minified script. I expect all my dependencies to be unminified to assist in debugging. If I want the minified version then I will map my dependencies to the *.min.js versions, or manually uglify all of them.

This update fixes this issue.

Also, the [bower.json spec](https://github.com/bower/bower.json-spec) instructs "Do not include minified files."
