### PR TITLE
Capture spy scope explicitly.

### DIFF
--- a/src/directives/scrollspy.js
+++ b/src/directives/scrollspy.js
@@ -2,12 +2,13 @@ angular.module('duScroll.scrollspy', ['duScroll.spyAPI'])
 .directive('duScrollspy', function(spyAPI, duScrollOffset, $timeout, $rootScope) {
   'use strict';
 
-  var Spy = function(targetElementOrId, $element, offset) {
+  var Spy = function(targetElementOrId, $scope, $element, offset) {
     if(angular.isElement(targetElementOrId)) {
       this.target = targetElementOrId;
     } else if(angular.isString(targetElementOrId)) {
       this.targetId = targetElementOrId;
     }
+    this.$scope = $scope;
     this.$element = $element;
     this.offset = offset;
   };
@@ -47,7 +48,7 @@ angular.module('duScroll.scrollspy', ['duScroll.spyAPI'])
       // Run this in the next execution loop so that the scroll context has a chance
       // to initialize
       $timeout(function() {
-        var spy = new Spy(targetId, $element, -($attr.offset ? parseInt($attr.offset, 10) : duScrollOffset));
+        var spy = new Spy(targetId, $scope, $element, -($attr.offset ? parseInt($attr.offset, 10) : duScrollOffset));
         spyAPI.addSpy(spy);
 
         $scope.$on('$destroy', function() {

--- a/src/services/spy-api.js
+++ b/src/services/spy-api.js
@@ -108,7 +108,7 @@ angular.module('duScroll.spyAPI', ['duScroll.scrollContainerAPI'])
   };
 
   var getContextForSpy = function(spy) {
-    var context, contextId, scope = spy.$element.scope();
+    var context, contextId, scope = spy.$scope;
     if(scope) {
       return getContextForScope(scope);
     }
@@ -139,7 +139,7 @@ angular.module('duScroll.spyAPI', ['duScroll.scrollContainerAPI'])
       if(context.container) {
         context.container.off('scroll', context.handler);
       }
-      context.container = scrollContainerAPI.getContainer(spy.$element.scope());
+      context.container = scrollContainerAPI.getContainer(spy.$scope);
       context.container.on('scroll', context.handler).triggerHandler('scroll');
     }
   };


### PR DESCRIPTION
This avoids calling `scope()`, thus allowing [disabling debug data](https://docs.angularjs.org/guide/production#disabling-debug-data) in Angular 1.3.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/oblador/angular-scroll/98)

<!-- Reviewable:end -->
