### PR TITLE
Optionally refresh spy positions at regular intervals

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -21,6 +21,9 @@ var duScroll = angular.module('duScroll', [
   .value('duScrollDuration', 350)
   //Scrollspy debounce interval, set to 0 to disable
   .value('duScrollSpyWait', 100)
+  //Scrollspy forced refresh interval, use if your content changes or reflows without scrolling.
+  //0 to disable
+  .value('duScrollSpyRefreshInterval', 0)
   //Wether or not multiple scrollspies can be active at once
   .value('duScrollGreedy', false)
   //Default offset for smoothScroll directive


### PR DESCRIPTION
Spies don't get updated when the document reflows without changing the scroll position, for example when the window gets resized or when elements further up the page are added/deleted.  This PR adds a `duScrollSpyRefreshInterval` option that will force the handler to execute every N milliseconds to check if the position changed.  The option is disabled by default.





<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable-dev-piotr.firebaseapp.com/reviews/oblador/angular-scroll/110)
<!-- Reviewable:end -->
