### PR TITLE
Try to look for a target with "name" attribute

### DIFF
--- a/angular-scroll.js
+++ b/angular-scroll.js
@@ -466,6 +466,10 @@ angular.module('duScroll.smoothScroll', ['duScroll.scrollHelpers', 'duScroll.scr
         if(!$attr.href || $attr.href.indexOf('#') === -1) return;
 
         var target = document.getElementById($attr.href.replace(/.*(?=#[^\s]+$)/, '').substring(1));
+        if (!target) {
+           // If the is no such id, try to look for names
+           target = document.getElementsByName($attr.href.replace(/.*(?=#[^\s]+$)/, '').substring(1))[0];
+        }
         if(!target || !target.getBoundingClientRect) return;
 
         if (e.stopPropagation) e.stopPropagation();


### PR DESCRIPTION
Often happens, that anchors are targeting not the elements marked with `id` attribute but ones which are marked with `name`. This as it expected to work in browser according to the standard. So, I think it is nice to reflect this behavior.

The use case:
Such a markup (with anchors targeting to the names) widely useful when generating md files with table of content. When inserting such a markup in the angular application, the anchors do not work even if using `duScroll`. If you could merge this pull request, the they will work :-) https://github.com/SC5/sc5-styleguide/issues/599