### PR TITLE
Clean up properly if scrollspy scope destroyed before timeout runs.

### DIFF
--- a/src/directives/scrollspy.js
+++ b/src/directives/scrollspy.js
@@ -49,7 +49,7 @@ angular.module('duScroll.scrollspy', ['duScroll.spyAPI'])
 
       // Run this in the next execution loop so that the scroll context has a chance
       // to initialize
-      $timeout(function() {
+      var timeoutPromise = $timeout(function() {
         var spy = new Spy(targetId, $scope, $element, -($attr.offset ? parseInt($attr.offset, 10) : duScrollOffset));
         spyAPI.addSpy(spy);
 
@@ -60,6 +60,7 @@ angular.module('duScroll.scrollspy', ['duScroll.spyAPI'])
           deregisterOnStateChange();
         });
       }, 0, false);
+      $scope.$on('$destroy', function() {$timeout.cancel(timeoutPromise);});
     }
   };
 });


### PR DESCRIPTION
In my app, an `ng-if` directive with a scrollspy on the same element bounces on/off/on very quickly for some reason.  That's probably a bug in itself, but as a result I end up with scrollspies on destroyed elements and scopes, which gets rather confusing.  This patch aborts the scrollspy initialization if the scope gets destroyed before the timeout fires.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/oblador/angular-scroll/149)
<!-- Reviewable:end -->
