### PR TITLE
Trigger becameInactive event when active spy destroyed.

### DIFF
--- a/src/services/spy-api.js
+++ b/src/services/spy-api.js
@@ -154,6 +154,7 @@ angular.module('duScroll.spyAPI', ['duScroll.scrollContainerAPI'])
   var removeSpy = function(spy) {
     var context = getContextForSpy(spy);
     if(spy === context.currentlyActive) {
+      $rootScope.$broadcast('duScrollspy:becameInactive', context.currentlyActive.$element);
       context.currentlyActive = null;
     }
     var i = context.spies.indexOf(spy);


### PR DESCRIPTION
When a spied-upon element is destroyed, and that spy is currently active, trigger the `duScrollspy:becameInactive` event.  This doesn't matter if the client code is just using the class for styling, but if it's actually making use of the `becameActive`/`becameInactive` events then the client will end up in the wrong state.  This also maintains symmetry with `addSpy`, which forces the handler to run (and possibly trigger `becameActive`) as soon as the spy is added.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/oblador/angular-scroll/152)
<!-- Reviewable:end -->
