### PR TITLE
Add `duScrollDelay` option for smoothScroll directive

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -78,7 +78,7 @@
   <nav>
     <ul>
       <li><a href="#section-1" du-smooth-scroll du-scrollspy>Section 1</a></li>
-      <li><a href="#section-2" du-smooth-scroll du-scrollspy>Section 2</a></li>
+      <li><a href="#section-2" du-smooth-scroll delay="500" du-scrollspy>Section 2</a></li>
       <li><a du-smooth-scroll="section-3" du-scrollspy>Section 3</a></li>
       <li><a href="http://github.com/oblador/angular-scroll/">Project on Github</a></li>
     </ul>

--- a/src/directives/smooth-scroll.js
+++ b/src/directives/smooth-scroll.js
@@ -1,9 +1,11 @@
 angular.module('duScroll.smoothScroll', ['duScroll.scrollHelpers', 'duScroll.scrollContainerAPI'])
-.directive('duSmoothScroll', function(duScrollDuration, duScrollOffset, scrollContainerAPI) {
+.directive('duSmoothScroll', function($timeout, duScrollDuration, duScrollDelay, duScrollOffset, scrollContainerAPI) {
   'use strict';
 
   return {
     link : function($scope, $element, $attr) {
+      var delayTimeout;
+
       $element.on('click', function(e) {
         if((!$attr.href || $attr.href.indexOf('#') === -1) && $attr.duSmoothScroll === '') return;
 
@@ -17,13 +19,24 @@ angular.module('duScroll.smoothScroll', ['duScroll.scrollHelpers', 'duScroll.scr
 
         var offset    = $attr.offset ? parseInt($attr.offset, 10) : duScrollOffset;
         var duration  = $attr.duration ? parseInt($attr.duration, 10) : duScrollDuration;
+        var delay  = $attr.delay ? parseInt($attr.delay, 10) : duScrollDelay;
         var container = scrollContainerAPI.getContainer($scope);
 
-        container.duScrollToElement(
-          angular.element(target),
-          isNaN(offset) ? 0 : offset,
-          isNaN(duration) ? 0 : duration
-        );
+        var scrollFn = function() {
+          container.duScrollToElement(
+            angular.element(target),
+            isNaN(offset) ? 0 : offset,
+            isNaN(duration) ? 0 : duration
+          );
+        }
+
+        if (delay) {
+          $timeout.cancel(delayTimeout);
+          delayTimeout = $timeout(scrollFn, delay);
+
+        } else {
+          scrollFn();
+        }
       });
     }
   };

--- a/src/module.js
+++ b/src/module.js
@@ -19,6 +19,8 @@ var duScroll = angular.module('duScroll', [
 ])
   //Default animation duration for smoothScroll directive
   .value('duScrollDuration', 350)
+  //Default animation delay for smoothScroll directive
+  .value('duScrollDelay', 0)
   //Scrollspy debounce interval, set to 0 to disable
   .value('duScrollSpyWait', 100)
   //Wether or not multiple scrollspies can be active at once


### PR DESCRIPTION
This is useful when you have an additional click event bound to the same element as the smoothScroll directive that should trigger an event before triggering the scroll.