### PR TITLE
Prevent angular from being required explicitly

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-require('angular');
 require('./angular-scroll');
 
 module.exports = 'duScroll';


### PR DESCRIPTION
Similar to the following PR: https://github.com/videogular/bower-videogular/pull/9. Placing angular as a dependency in `index.js` causes `WARNING: Tried to load angular more than once.`.