### PR TITLE
Guard against race condition when removing spies

### DIFF
--- a/src/services/spy-api.js
+++ b/src/services/spy-api.js
@@ -28,7 +28,7 @@ angular.module('duScroll.spyAPI', ['duScroll.scrollContainerAPI'])
       for(i = 0; i < spies.length; i++) {
         spy = spies[i];
         pos = spy.getTargetPosition();
-        if (!pos) continue;
+        if (!pos || !spy.$element) continue;
 
         if((duScrollBottomSpy && bottomReached) || (pos.top + spy.offset - containerOffset < 20 && (duScrollGreedy || pos.top*-1 + containerOffset) < pos.height)) {
           //Find the one closest the viewport top or the page bottom if it's reached


### PR DESCRIPTION
It seems that -- extremely rarely -- it's possible for a spy to be removed, nulling out its `$element`, but still be seen by the handler.  My guess is that the handler gets queued in Angular's internal deferred actions, then before it can execute the context is destroyed and the spy removed (but not removed from the context's list due to the ordering).  Then when the handler executes it can activate a spy with a `null` `$element`, which causes a crash.  I didn't bother to track down the root cause precisely because it's so rare (one occurrence in over a year), and so easy to protect against.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/oblador/angular-scroll/166)
<!-- Reviewable:end -->
