### PR TITLE
dont use el.scrollTo, use doScrollTo

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -28,7 +28,7 @@ angular.module('duScroll.scrollHelpers', ['duScroll.requestAnimation'])
     }
     var el = unwrap(this);
     if(isDocument(el)) {
-      return $window.duScrollTo(left, top);
+      return angular.element($window).duScrollTo(left, top);
     }
     el.scrollLeft = left;
     el.scrollTop = top;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -28,7 +28,7 @@ angular.module('duScroll.scrollHelpers', ['duScroll.requestAnimation'])
     }
     var el = unwrap(this);
     if(isDocument(el)) {
-      return $window.scrollTo(left, top);
+      return $window.duScrollTo(left, top);
     }
     el.scrollLeft = left;
     el.scrollTop = top;
@@ -79,7 +79,7 @@ angular.module('duScroll.scrollHelpers', ['duScroll.requestAnimation'])
       progress = timestamp - startTime;
       var percent = (progress >= duration ? 1 : easing(progress/duration));
 
-      el.scrollTo(
+      el.duScrollTo(
         startLeft + Math.ceil(deltaLeft * percent),
         startTop + Math.ceil(deltaTop * percent)
       );


### PR DESCRIPTION
I happen to have jquery.scrollTo installed which has a different api than your `scrollTo` method. It overwrites your method with its own. 

Your method takes params of (left, top,  ... ) while their method is (top, ....) which is really bad. 

without this fix, I am forced to remove scrollTo and rewrite some legacy cod to make use of your scrollTo method, which is ok, but not ideal.

Also the bug this caused was hard to track down.
