### PR TITLE
Guard against last minute removal of toBeActive spy

### DIFF
--- a/src/services/spy-api.js
+++ b/src/services/spy-api.js
@@ -53,6 +53,7 @@ angular.module('duScroll.spyAPI', ['duScroll.scrollContainerAPI'])
           angular.element(currentlyActive.getTargetElement())
         );
       }
+      if(toBeActive && !toBeActive.$element) toBeActive = undefined;
       if(toBeActive) {
         toBeActive.$element.addClass(duScrollActiveClass);
         $rootScope.$broadcast(


### PR DESCRIPTION
Since the broadcast of `becameInactive` is synchronous, it's possible for the `toBeActive` spy to be removed by client code just before it gets activated.  This change guards against this (admittedly extremely rare) scenario by treating the spy as if though it didn't exist in the first place.  Note that it's possible that another spy should've been selected instead, then, but since the condition is so rare it's probably OK to wait until the next interval fires to recompute the actual active spy.