### PR TITLE
Fix bug: wrong scroll on Safari Mobile

### DIFF
--- a/angular-scroll.js
+++ b/angular-scroll.js
@@ -113,6 +113,10 @@ angular.module('duScroll.scrollHelpers', ['duScroll.requestAnimation'])
     }
 
     var animationStep = function(timestamp) {
+      if (typeof timestamp === 'undefined') {
+        timestamp = new Date().getTime();
+      }
+
       if (startTime === null) {
         startTime = timestamp;
       }

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -72,6 +72,10 @@ angular.module('duScroll.scrollHelpers', ['duScroll.requestAnimation'])
     }
 
     var animationStep = function(timestamp) {
+      if (typeof timestamp === 'undefined') {
+        timestamp = new Date().getTime();
+      }
+
       if (startTime === null) {
         startTime = timestamp;
       }


### PR DESCRIPTION
Scroll always occurs to the beginning of the document. This is because the top position is evaluated to `NaN` because `timestamp` passed to `animationStep` is `undefined`.

Bug reproduced with versions 8 and 9 of Safari Mobile.

The solution is to check whether `timestamp` is undefined and set to it the current time when it's the case.