### PR TITLE
correct scrollspy to account for offset

### DIFF
--- a/angular-scroll.js
+++ b/angular-scroll.js
@@ -288,7 +288,7 @@ angular.module('duScroll.spyAPI', ['duScroll.scrollContainerAPI'])
         pos = spy.getTargetPosition();
         if (!pos || !spy.$element) continue;
 
-        if((duScrollBottomSpy && bottomReached) || (pos.top + spy.offset - containerOffset < 20 && (duScrollGreedy || pos.top*-1 + containerOffset) < pos.height)) {
+        if((duScrollBottomSpy && bottomReached) || (((pos.top + spy.offset - containerOffset) < 20) && (duScrollGreedy || (((pos.top*-1) + (containerOffset - spy.offset)) < pos.height)))) {
           //Find the one closest the viewport top or the page bottom if it's reached
           if(!toBeActive || toBeActive[compareProperty] < pos[compareProperty]) {
             toBeActive = {


### PR DESCRIPTION
Scrollspy was not taking account of optional offset parameter. 

See attached images for before and after examples. Page shown uses a sticky header (hence the need for the offset parameter) and a sidebar tree of bookmarks.

::attached images removed::
