### PR TITLE
add rejection handler (angular.noop) in duSmoothScroll directive

### DIFF
--- a/src/directives/smooth-scroll.js
+++ b/src/directives/smooth-scroll.js
@@ -23,7 +23,7 @@ angular.module('duScroll.smoothScroll', ['duScroll.scrollHelpers', 'duScroll.scr
           angular.element(target),
           isNaN(offset) ? 0 : offset,
           isNaN(duration) ? 0 : duration
-        );
+        ).catch(angular.noop);
       });
     }
   };


### PR DESCRIPTION
Add a rejection handler (angular.noop) in the duSmoothScroll directive in order to prevent "Possibly unhandled rejection" errors with AngularJS >= 1.6 in case the user cancels the scroll animation.

Steps to reproduce:
1. Open [this plunker](https://embed.plnkr.co/r0gyoYsuEqwoSBJOdcQr/).
2. Double click the links which trigger animated scrolling (Section 1, 2, 3)
3. The second click will always cancel the animated scrolling if you're fast enough.
4. Check the browser console to see the "Possibly unhandled rejection" errors.

Some more details regarding unhandled promise rejections can be found in [this blog post](http://www.codelord.net/2017/08/20/angular-1-dot-6-s-possibly-unhandled-rejection-errors/).